### PR TITLE
[BBMSK- 25] Field configurator refactor

### DIFF
--- a/src/admin/components/FieldConfigurator.js
+++ b/src/admin/components/FieldConfigurator.js
@@ -1,17 +1,14 @@
-import {
-	CheckboxControl,
-	TextControl,
-	ToggleControl,
-} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
+import classNames from 'classnames';
 
 import OptionConfig from './OptionConfig';
-import { getAttributes } from '../fields';
+import { getAttributes, getConfig } from '../fields';
 
 const FieldConfigurator = ( { field, setting, setNewSetting } ) => {
 	/**
-	 * Set the new setting with default attributes when the field changes and on first mount
+	 * Set the new setting with default attributes when the
+	 * field changes and on first mount
 	 */
 	useEffect( () => {
 		setNewSetting( {
@@ -32,141 +29,65 @@ const FieldConfigurator = ( { field, setting, setNewSetting } ) => {
 		} );
 	};
 
+	const renderFieldConfig = () => {
+		const fieldConfig = getConfig( field );
+
+		if ( ! fieldConfig ) {
+			return null;
+		}
+
+		if ( fieldConfig.options ) {
+			return (
+				<OptionConfig
+					optionsKey={ fieldConfig.optionsKey }
+					setting={ setting }
+					handleAttributeChange={ handleAttributeChange }
+					optionsHeader={ fieldConfig.optionsHeader }
+					newOption={ fieldConfig.newOption }
+					controls={ fieldConfig.controls }
+				/>
+			);
+		}
+
+		return fieldConfig.controls.map( ( control, index ) => {
+			const Control = control.component;
+			/**
+			 * Dynamically set the prop based on the control componentProp,
+			 * getting the correct value from the setting object.
+			 * E.g checked, value etc
+			 */
+			const dynamicProp = {
+				[ control.componentProp ]:
+					setting?.[ control.settingKey ] || '',
+			};
+
+			return (
+				<Control
+					key={ index }
+					className={ classNames( {
+						'form-field--required': control.required,
+					} ) }
+					label={ control.label }
+					required={ control.required }
+					{ ...dynamicProp }
+					onChange={ ( value ) =>
+						handleAttributeChange( control.settingKey, value )
+					}
+				/>
+			);
+		} );
+	};
+
 	return (
 		<div className="field-config">
 			<h3>{ __( 'Field Configuration', 'bb_site_settings' ) }</h3>
-
 			<p>
 				{ __(
 					'Configure the field for the setting',
 					'bb_site_settings'
 				) }
 			</p>
-			<div className="field-config__field">
-				{ field === 'text' && (
-					<div className="field-config__options">
-						<TextControl
-							className="form-field--required"
-							required
-							label={ __(
-								'Label for field',
-								'bb_site_settings'
-							) }
-							value={ setting?.label || '' }
-							onChange={ ( value ) =>
-								handleAttributeChange( 'label', value )
-							}
-						/>
-						<TextControl
-							label={ __(
-								'Value for field',
-								'bb_site_settings'
-							) }
-							value={ setting?.value || '' }
-							onChange={ ( value ) => {
-								handleAttributeChange( 'value', value );
-							} }
-						/>
-					</div>
-				) }
-
-				{ field === 'toggle' && (
-					<div className="field-config__options">
-						<TextControl
-							className="form-field--required"
-							required
-							label={ __(
-								'Label for field',
-								'bb_site_settings'
-							) }
-							value={ setting?.label || '' }
-							onChange={ ( value ) =>
-								handleAttributeChange( 'label', value )
-							}
-						/>
-						<ToggleControl
-							label={ __(
-								'Value for field',
-								'bb_site_settings'
-							) }
-							checked={ setting?.checked || false }
-							onChange={ ( value ) => {
-								handleAttributeChange( 'checked', value );
-							} }
-						/>
-					</div>
-				) }
-
-				{ field === 'radio' && (
-					<OptionConfig
-						setting={ setting }
-						handleAttributeChange={ handleAttributeChange }
-						optionsHeader={ __(
-							'Radio options',
-							'bb_site_settings'
-						) }
-						config={ {
-							newOption: { label: '', value: '' },
-							controls: [
-								{
-									type: TextControl,
-									required: true,
-									label: __(
-										'Option Label',
-										'bb_site_settings'
-									),
-									updateField: 'label',
-									valueProp: 'value',
-								},
-								{
-									type: TextControl,
-									label: __(
-										'Option Value',
-										'bb_site_settings'
-									),
-									updateField: 'value',
-									valueProp: 'value',
-								},
-							],
-						} }
-					/>
-				) }
-
-				{ field === 'checkbox-group' && (
-					<OptionConfig
-						setting={ setting }
-						handleAttributeChange={ handleAttributeChange }
-						optionsHeader={ __(
-							'Checkbox options',
-							'bb_site_settings'
-						) }
-						config={ {
-							newOption: { label: '', checked: false },
-							controls: [
-								{
-									type: TextControl,
-									required: true,
-									label: __(
-										'Option Label',
-										'bb_site_settings'
-									),
-									updateField: 'label',
-									valueProp: 'value',
-								},
-								{
-									type: CheckboxControl,
-									label: __(
-										'Option Value',
-										'bb_site_settings'
-									),
-									updateField: 'checked',
-									valueProp: 'checked',
-								},
-							],
-						} }
-					/>
-				) }
-			</div>
+			<div className="field-config__field">{ renderFieldConfig() }</div>
 		</div>
 	);
 };

--- a/src/admin/fields/fieldConfigs.js
+++ b/src/admin/fields/fieldConfigs.js
@@ -1,0 +1,167 @@
+import {
+	TextControl,
+	ToggleControl,
+	RadioControl,
+	CheckboxControl,
+} from '@wordpress/components';
+import { v4 as uuidv4 } from 'uuid';
+import { __ } from '@wordpress/i18n';
+
+import CheckboxGroup from './CheckboxGroup';
+
+const LABELS = {
+	FIELD: __( 'Label for field', 'bb_site_settings' ),
+	VALUE: __( 'Value for field', 'bb_site_settings' ),
+	OPTION_LABEL: __( 'Option Label', 'bb_site_settings' ),
+	OPTION_VALUE: __( 'Option value', 'bb_site_settings' ),
+};
+
+const fieldConfigs = {
+	text: {
+		Component: TextControl,
+		keyProp: 'value',
+		label: __( 'Text', 'bb_site_settings' ),
+		attributes: {
+			label: 'Text Label',
+			value: '',
+		},
+		config: {
+			controls: [
+				{
+					component: TextControl,
+					required: true,
+					label: LABELS.FIELD,
+					componentProp: 'value',
+					settingKey: 'label',
+				},
+				{
+					component: TextControl,
+					label: LABELS.VALUE,
+					componentProp: 'value',
+					settingKey: 'value',
+				},
+			],
+		},
+	},
+	toggle: {
+		Component: ToggleControl,
+		keyProp: 'checked',
+		label: __( 'Toggle', 'bb_site_settings' ),
+		attributes: {
+			label: 'Toggle Label',
+			checked: false,
+		},
+		config: {
+			controls: [
+				{
+					component: TextControl,
+					required: true,
+					label: LABELS.FIELD,
+					componentProp: 'value',
+					settingKey: 'label',
+				},
+				{
+					component: ToggleControl,
+					label: LABELS.VALUE,
+					componentProp: 'checked',
+					settingKey: 'checked',
+				},
+			],
+		},
+	},
+	'checkbox-group': {
+		Component: CheckboxGroup,
+		keyProp: 'options',
+		label: __( 'Checkbox Group', 'bb_site_settings' ),
+		attributes: {
+			label: 'Checkbox Group Label',
+			options: [
+				{
+					label: 'Checkbox 1',
+					checked: false,
+					id: uuidv4(),
+				},
+				{
+					label: 'Checkbox 2',
+					checked: false,
+					id: uuidv4(),
+				},
+				{
+					label: 'Checkbox 3',
+					checked: false,
+					id: uuidv4(),
+				},
+			],
+		},
+		config: {
+			options: true,
+			optionsKey: 'options',
+			optionsHeader: __( 'Checkbox Options', 'bb_site_settings' ),
+			newOption: { label: '', checked: false },
+			controls: [
+				{
+					component: TextControl,
+					required: true,
+					label: LABELS.OPTION_LABEL,
+					optionKey: 'label',
+					componentProp: 'value',
+				},
+				{
+					component: CheckboxControl,
+					label: LABELS.OPTION_VALUE,
+					optionKey: 'checked',
+					componentProp: 'checked',
+				},
+			],
+		},
+	},
+	radio: {
+		Component: RadioControl,
+		keyProp: 'selected',
+		label: __( 'Radio', 'bb_site_settings' ),
+		attributes: {
+			label: 'Radio Label',
+			selected: null,
+			options: [
+				{
+					label: 'Option 1',
+					value: '1',
+					id: uuidv4(),
+				},
+				{
+					label: 'Option 2',
+					value: '2',
+					id: uuidv4(),
+				},
+				{
+					label: 'Option 3',
+					value: '3',
+					id: uuidv4(),
+				},
+			],
+		},
+		config: {
+			options: true,
+			optionsKey: 'options',
+			optionsHeader: __( 'Radio Options', 'bb_site_settings' ),
+			newOption: { label: '', value: '' },
+			controls: [
+				{
+					component: TextControl,
+					required: true,
+					label: LABELS.OPTION_LABEL,
+					optionKey: 'label',
+					componentProp: 'value',
+				},
+				{
+					component: TextControl,
+					label: LABELS.OPTION_VALUE,
+					optionKey: 'value',
+					componentProp: 'value',
+				},
+			],
+		},
+	},
+};
+
+export default fieldConfigs;

--- a/src/admin/fields/supportedFields.js
+++ b/src/admin/fields/supportedFields.js
@@ -1,91 +1,22 @@
 import { __ } from '@wordpress/i18n';
-import {
-	TextControl,
-	ToggleControl,
-	RadioControl,
-} from '@wordpress/components';
-import { v4 as uuidv4 } from 'uuid';
 
-import CheckboxGroup from './CheckboxGroup';
+import fieldConfigs from './fieldConfigs';
 
-const supportedFields = {
-	text: {
-		Component: TextControl,
-		keyProp: 'value',
-		label: __( 'Text', 'bb_site_settings' ),
-		attributes: {
-			label: 'Text Label',
-			value: '',
-		},
-	},
-	toggle: {
-		Component: ToggleControl,
-		keyProp: 'checked',
-		label: __( 'Toggle', 'bb_site_settings' ),
-		attributes: {
-			label: 'Toggle Label',
-			checked: false,
-		},
-	},
-	'checkbox-group': {
-		Component: CheckboxGroup,
-		keyProp: 'options',
-		label: __( 'Checkbox Group', 'bb_site_settings' ),
-		attributes: {
-			label: 'Checkbox Group Label',
-			options: [
-				{
-					label: 'Checkbox 1',
-					checked: false,
-					id: uuidv4(),
-				},
-				{
-					label: 'Checkbox 2',
-					checked: false,
-					id: uuidv4(),
-				},
-				{
-					label: 'Checkbox 3',
-					checked: false,
-					id: uuidv4(),
-				},
-			],
-		},
-	},
-	radio: {
-		Component: RadioControl,
-		keyProp: 'selected',
-		label: __( 'Radio', 'bb_site_settings' ),
-		attributes: {
-			label: 'Radio Label',
-			selected: null,
-			options: [
-				{
-					label: 'Option 1',
-					value: '1',
-					id: uuidv4(),
-				},
-				{
-					label: 'Option 2',
-					value: '2',
-					id: uuidv4(),
-				},
-				{
-					label: 'Option 3',
-					value: '3',
-					id: uuidv4(),
-				},
-			],
-		},
-	},
-};
+/**
+ * Returns the config for a given field used for the field configurator
+ *
+ * @param {string} field - field name
+ *
+ * @return {Object | undefined} Config for the given field
+ */
+const getConfig = ( field ) => fieldConfigs[ field ]?.config;
 
 /**
  * Returns an array of supported fields
  *
  * @return {string[]} Array of supported fields
  */
-const getSupportedfields = () => Object.keys( supportedFields );
+const getSupportedfields = () => Object.keys( fieldConfigs );
 
 /**
  * Returns the component for a given field
@@ -94,7 +25,7 @@ const getSupportedfields = () => Object.keys( supportedFields );
  *
  * @return {Component | undefined} Component for the given field
  */
-const getComponent = ( field ) => supportedFields[ field ]?.Component;
+const getComponent = ( field ) => fieldConfigs[ field ]?.Component;
 
 /**
  * Returns the attributes for a given field
@@ -103,7 +34,7 @@ const getComponent = ( field ) => supportedFields[ field ]?.Component;
  *
  * @return {Object | undefined} Attributes for the given field
  */
-const getAttributes = ( field ) => supportedFields[ field ]?.attributes;
+const getAttributes = ( field ) => fieldConfigs[ field ]?.attributes;
 
 /**
  * Returns the key prop for a given field
@@ -112,7 +43,7 @@ const getAttributes = ( field ) => supportedFields[ field ]?.attributes;
  *
  * @return {string | undefined} Key prop for the given field
  */
-const getKeyProp = ( field ) => supportedFields[ field ]?.keyProp;
+const getKeyProp = ( field ) => fieldConfigs[ field ]?.keyProp;
 
 /**
  * Returns an array of supported fields in select options format
@@ -125,8 +56,8 @@ const getSelectSupportedOptions = () => [
 		label: __( 'Select field', 'bb_site_settings' ),
 		value: '',
 	},
-	...Object.keys( supportedFields ).map( ( key ) => ( {
-		label: supportedFields[ key ].label,
+	...Object.keys( fieldConfigs ).map( ( key ) => ( {
+		label: fieldConfigs[ key ].label,
 		value: key,
 	} ) ),
 ];
@@ -137,4 +68,5 @@ export {
 	getSelectSupportedOptions,
 	getSupportedfields,
 	getKeyProp,
+	getConfig,
 };


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
Titles should use Jira ticket references and title where applicable.
Example: [JIRA-0001] Outline additional requested information for Pull Requests.
--->

## Description

<!---
Please ensure `{[JIRA-0000](jira-url)} - {Description}` is used and that descriptions are as thorough as they can be. If there are related Jira tickets, please ensure those are included as above. GitHub issues can also be used in replacement and should use keyword links: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
Example format:
Fixes #123 and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We've found that additional information is required to aid with understanding on what is required from a PR, and that further clarification is needed for other areas. This PR adds some additional information to the PR template to ensure engineers are providing the correct information on Pull Requests and that the QA is getting the information they need for testing.
--->

Providing a way to add new supported fields by updating the supportedComponents config. Updated FieldConfigurator component to be config driven and updated OptionConfig to be flexible 

## Change Log

<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->

## Steps to test

<!--- Please describe how you tested your changes and how a reviewer can do the same. --->

## Screenshots/Videos

<!--- Please include a video demonstrating how to use new features. This may include setup. Nothing has to be perfect. --->

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
